### PR TITLE
Reemplazado uso de queryForObject deprecado

### DIFF
--- a/generateCode/dao/{{tableName}}DaoImpl.java.jinja
+++ b/generateCode/dao/{{tableName}}DaoImpl.java.jinja
@@ -347,7 +347,7 @@ public class {{tableName}}DaoImpl implements {{tableName}}Dao {
 		
 		List<?> params = (List<?>) mapaWhere.get("params");
 		
-		return this.jdbcTemplate.queryForObject(query.toString(), params.toArray(), Long.class);
+		return this.jdbcTemplate.queryForObject(query.toString(), Long.class, params.toArray());		
 	}
 
 		/**
@@ -399,7 +399,7 @@ public class {{tableName}}DaoImpl implements {{tableName}}Dao {
 
 		List<?> params = (List<?>) mapaWhere.get("params");
 
-		return this.jdbcTemplate.queryForObject(query.toString(), params.toArray(), Long.class);
+		return this.jdbcTemplate.queryForObject(query.toString(), Long.class, params.toArray());		
 	}
 
 	@Override


### PR DESCRIPTION
Se ha actualizado el uso de JdbcTemplate.queryForObject(...) para evitar el uso de la versión con Object[] como parámetro, ya que está deprecada desde Spring Framework 5.3.
En su lugar, se utiliza la versión con varargs (Object... args), tal y como se recomienda en la documentación oficial.

🔗 Documentación oficial de Spring:
https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-5.3-Release-Notes#data-access-and-transactions